### PR TITLE
IAD departure headings clarification

### DIFF
--- a/public/ZDC_quickreference/kiad-departurehdgs.html
+++ b/public/ZDC_quickreference/kiad-departurehdgs.html
@@ -11,7 +11,7 @@
 <tr>
 <th rowspan=2 colspan=2 bgcolor="ff99ff">Departure</th>
 <th rowspan=2 bgcolor="ff99ff">First Waypoint</th>
-<th rowspan=2 bgcolor="ff99ff">Ideal Heading</th>
+<th rowspan=2 bgcolor="ff99ff">Ref Hdg<br><i><font color="ff0000" size=-1>(do not issue)</font></i></th>
 <th colspan=5 bgcolor="ff99ff">Configuration</th>
 </tr>
 
@@ -27,7 +27,7 @@
 <th rowspan=24 bgcolor="ff99ff">ASPER<br>(North / East)</th>
 <th bgcolor="ff99ff">JCOBY#</th>
 <td align=center>RIGNZ</td>
-<td align=center>039</td>
+<td align=center bgcolor="bbbbbb">039</td>
 <td align=center>300<br><i>(280-300)</i></td>
 <td align=center>320<br><i>(280-320)</i></td>
 <td align=center>310<br><i>(300-310)</i></td>
@@ -38,7 +38,7 @@
 <tr>
 <th bgcolor="ff99ff">JERES#</th>
 <td align=center>IDORE</td>
-<td align=center>359</td>
+<td align=center bgcolor="bbbbbb">359</td>
 <td align=center>300<br><i>(280-300)</i></td>
 <td align=center>320<br><i>(280-320)</i></td>
 <td align=center>310<br><i>(300-310)</i></td>
@@ -49,7 +49,7 @@
 <tr>
 <th bgcolor="ff99ff">MCRAY#</th>
 <td align=center>HAYGR</td>
-<td align=center>341</td>
+<td align=center bgcolor="bbbbbb">341</td>
 <td align=center>300<br><i>(280-300)</i></td>
 <td align=center>320<br><i>(280-320)</i></td>
 <td align=center>310<br><i>(300-310)</i></td>
@@ -60,7 +60,7 @@
 <tr>
 <th bgcolor="ff99ff">WOOLY#</th>
 <td align=center>RAZZA</td>
-<td align=center>034</td>
+<td align=center bgcolor="bbbbbb">034</td>
 <td align=center>300<br><i>(280-300)</i></td>
 <td align=center>320<br><i>(280-320)</i></td>
 <td align=center>310<br><i>(300-310)</i></td>
@@ -71,7 +71,7 @@
 <tr>
 <th rowspan=20 bgcolor="ff99ff">Radar Vectors</th>
 <td align=center>AGARD</td>
-<td align=center>094</td>
+<td align=center bgcolor="bbbbbb">094</td>
 <td align=center>300<br><i>(280-300)</i></td>
 <td align=center>320<br><i>(280-320)</i></td>
 <td align=center>310<br><i>(300-310)</i></td>
@@ -81,7 +81,7 @@
 
 <tr>
 <td align=center>ANNGE</td>
-<td align=center>077</td>
+<td align=center bgcolor="bbbbbb">077</td>
 <td align=center>300<br><i>(280-300)</i></td>
 <td align=center>320<br><i>(280-320)</i></td>
 <td align=center>310<br><i>(300-310)</i></td>
@@ -91,7 +91,7 @@
 
 <tr>
 <td align=center>BAL</td>
-<td align=center>080</td>
+<td align=center bgcolor="bbbbbb">080</td>
 <td align=center>300<br><i>(280-300)</i></td>
 <td align=center>320<br><i>(280-320)</i></td>
 <td align=center>310<br><i>(300-310)</i></td>
@@ -101,7 +101,7 @@
 
 <tr>
 <td align=center>BUFFR</td>
-<td align=center>358</td>
+<td align=center bgcolor="bbbbbb">358</td>
 <td align=center>300<br><i>(280-300)</i></td>
 <td align=center>320<br><i>(280-320)</i></td>
 <td align=center>310<br><i>(300-310)</i></td>
@@ -111,7 +111,7 @@
 
 <tr>
 <td align=center>COLIN</td>
-<td align=center>153</td>
+<td align=center bgcolor="bbbbbb">153</td>
 <td align=center>300<br><i>(280-300)</i></td>
 <td align=center>320<br><i>(280-320)</i></td>
 <td align=center>310<br><i>(300-310)</i></td>
@@ -121,7 +121,7 @@
 
 <tr>
 <td align=center>DAILY</td>
-<td align=center>134</td>
+<td align=center bgcolor="bbbbbb">134</td>
 <td align=center>300<br><i>(280-300)</i></td>
 <td align=center>320<br><i>(280-320)</i></td>
 <td align=center>310<br><i>(300-310)</i></td>
@@ -131,7 +131,7 @@
 
 <tr>
 <td align=center>DCA</td>
-<td align=center>115</td>
+<td align=center bgcolor="bbbbbb">115</td>
 <td align=center>300<br><i>(280-300)</i></td>
 <td align=center>320<br><i>(280-320)</i></td>
 <td align=center>310<br><i>(300-310)</i></td>
@@ -141,7 +141,7 @@
 
 <tr>
 <td align=center>EMI</td>
-<td align=center>044</td>
+<td align=center bgcolor="bbbbbb">044</td>
 <td align=center>300<br><i>(280-300)</i></td>
 <td align=center>320<br><i>(280-320)</i></td>
 <td align=center>310<br><i>(300-310)</i></td>
@@ -151,7 +151,7 @@
 
 <tr>
 <td align=center>ENO</td>
-<td align=center>089</td>
+<td align=center bgcolor="bbbbbb">089</td>
 <td align=center>300<br><i>(280-300)</i></td>
 <td align=center>320<br><i>(280-320)</i></td>
 <td align=center>310<br><i>(300-310)</i></td>
@@ -161,7 +161,7 @@
 
 <tr>
 <td align=center>JCOBY</td>
-<td align=center>060</td>
+<td align=center bgcolor="bbbbbb">060</td>
 <td align=center>300<br><i>(280-300)</i></td>
 <td align=center>320<br><i>(280-320)</i></td>
 <td align=center>310<br><i>(300-310)</i></td>
@@ -171,7 +171,7 @@
 
 <tr>
 <td align=center>JERES</td>
-<td align=center>010</td>
+<td align=center bgcolor="bbbbbb">010</td>
 <td align=center>300<br><i>(280-300)</i></td>
 <td align=center>320<br><i>(280-320)</i></td>
 <td align=center>310<br><i>(300-310)</i></td>
@@ -181,7 +181,7 @@
 
 <tr>
 <td align=center>MCRAY</td>
-<td align=center>342</td>
+<td align=center bgcolor="bbbbbb">342</td>
 <td align=center>300<br><i>(280-300)</i></td>
 <td align=center>320<br><i>(280-320)</i></td>
 <td align=center>310<br><i>(300-310)</i></td>
@@ -191,7 +191,7 @@
 
 <tr>
 <td align=center>MRB</td>
-<td align=center>336</td>
+<td align=center bgcolor="bbbbbb">336</td>
 <td align=center>300<br><i>(280-300)</i></td>
 <td align=center>320<br><i>(280-320)</i></td>
 <td align=center>310<br><i>(300-310)</i></td>
@@ -201,7 +201,7 @@
 
 <tr>
 <td align=center>PALEO</td>
-<td align=center>094</td>
+<td align=center bgcolor="bbbbbb">094</td>
 <td align=center>300<br><i>(280-300)</i></td>
 <td align=center>320<br><i>(280-320)</i></td>
 <td align=center>310<br><i>(300-310)</i></td>
@@ -211,7 +211,7 @@
 
 <tr>
 <td align=center>PEEGE</td>
-<td align=center>096</td>
+<td align=center bgcolor="bbbbbb">096</td>
 <td align=center>300<br><i>(280-300)</i></td>
 <td align=center>320<br><i>(280-320)</i></td>
 <td align=center>310<br><i>(300-310)</i></td>
@@ -221,7 +221,7 @@
 
 <tr>
 <td align=center>RAZZA</td>
-<td align=center>034</td>
+<td align=center bgcolor="bbbbbb">034</td>
 <td align=center>300<br><i>(280-300)</i></td>
 <td align=center>320<br><i>(280-320)</i></td>
 <td align=center>310<br><i>(300-310)</i></td>
@@ -231,7 +231,7 @@
 
 <tr>
 <td align=center>SOOKI</td>
-<td align=center>087</td>
+<td align=center bgcolor="bbbbbb">087</td>
 <td align=center>300<br><i>(280-300)</i></td>
 <td align=center>320<br><i>(280-320)</i></td>
 <td align=center>310<br><i>(300-310)</i></td>
@@ -241,7 +241,7 @@
 
 <tr>
 <td align=center>SWANN</td>
-<td align=center>088</td>
+<td align=center bgcolor="bbbbbb">088</td>
 <td align=center>300<br><i>(280-300)</i></td>
 <td align=center>320<br><i>(280-320)</i></td>
 <td align=center>310<br><i>(300-310)</i></td>
@@ -251,7 +251,7 @@
 
 <tr>
 <td align=center>WHINO</td>
-<td align=center>142</td>
+<td align=center bgcolor="bbbbbb">142</td>
 <td align=center>300<br><i>(280-300)</i></td>
 <td align=center>320<br><i>(280-320)</i></td>
 <td align=center>310<br><i>(300-310)</i></td>
@@ -261,7 +261,7 @@
 
 <tr>
 <td align=center>WOOLY</td>
-<td align=center>050</td>
+<td align=center bgcolor="bbbbbb">050</td>
 <td align=center>300<br><i>(280-300)</i></td>
 <td align=center>320<br><i>(280-320)</i></td>
 <td align=center>310<br><i>(300-310)</i></td>
@@ -276,7 +276,7 @@
 <tr>
 <th rowspan=2 colspan=2 bgcolor="ff99ff">Departure</th>
 <th rowspan=2 bgcolor="ff99ff">First Waypoint</th>
-<th rowspan=2 bgcolor="ff99ff">Ideal Heading</th>
+<th rowspan=2 bgcolor="ff99ff">Ref Hdg<br><i><font color="ff0000" size=-1>(do not issue)</font></i></th>
 <th colspan=5 bgcolor="ff99ff">Configuration</th>
 </tr>
 
@@ -303,7 +303,7 @@
 <tr>
 <th bgcolor="ff99ff">CLTCH#</th>
 <td align=center>BUTRZ</td>
-<td align=center>222</td>
+<td align=center bgcolor="bbbbbb">222</td>
 <td align=center>250<br><i>(250-280)</i></td>
 <td align=center>220<br><i>(190-280)</i></td>
 <td align=center>280<br><i>(280-300)</i></td>
@@ -314,7 +314,7 @@
 <tr>
 <th bgcolor="ff99ff">JDUBB#</th>
 <td align=center>HAFNR</td>
-<td align=center>199</td>
+<td align=center bgcolor="bbbbbb">199</td>
 <td align=center>250<br><i>(250-280)</i></td>
 <td align=center>200<br><i>(190-280)</i></td>
 <td align=center>280<br><i>(280-300)</i></td>
@@ -336,7 +336,7 @@
 <tr>
 <th bgcolor="ff99ff">SCRAM#</th>
 <td align=center>POOCH</td>
-<td align=center>209</td>
+<td align=center bgcolor="bbbbbb">209</td>
 <td align=center>250<br><i>(250-280)</i></td>
 <td align=center>210<br><i>(190-280)</i></td>
 <td align=center>280<br><i>(280-300)</i></td>
@@ -347,7 +347,7 @@
 <tr>
 <th rowspan=15 bgcolor="ff99ff">Radar Vectors</th>
 <td align=center>BLUES</td>
-<td align=center>257</td>
+<td align=center bgcolor="bbbbbb">257</td>
 <td align=center>255<br><i>(250-280)</i></td>
 <td align=center>255<br><i>(190-280)</i></td>
 <td align=center>280<br><i>(280-300)</i></td>
@@ -357,7 +357,7 @@
 
 <tr>
 <td align=center>BRV</td>
-<td align=center>182</td>
+<td align=center bgcolor="bbbbbb">182</td>
 <td align=center>250<br><i>(250-280)</i></td>
 <td align=center>190<br><i>(190-280)</i></td>
 <td align=center>280<br><i>(280-300)</i></td>
@@ -367,7 +367,7 @@
 
 <tr>
 <td align=center>BUNZZ</td>
-<td align=center>269</td>
+<td align=center bgcolor="bbbbbb">269</td>
 <td align=center>270<br><i>(250-280)</i></td>
 <td align=center>270<br><i>(190-280)</i></td>
 <td align=center>280<br><i>(280-300)</i></td>
@@ -377,7 +377,7 @@
 
 <tr>
 <td align=center>BUTRZ</td>
-<td align=center>222</td>
+<td align=center bgcolor="bbbbbb">222</td>
 <td align=center>250<br><i>(250-280)</i></td>
 <td align=center>220<br><i>(190-280)</i></td>
 <td align=center>280<br><i>(280-300)</i></td>
@@ -387,7 +387,7 @@
 
 <tr>
 <td align=center>CSN</td>
-<td align=center>236</td>
+<td align=center bgcolor="bbbbbb">236</td>
 <td align=center>250<br><i>(250-280)</i></td>
 <td align=center>235<br><i>(190-280)</i></td>
 <td align=center>280<br><i>(280-300)</i></td>
@@ -397,7 +397,7 @@
 
 <tr>
 <td align=center>FLUKY</td>
-<td align=center>216</td>
+<td align=center bgcolor="bbbbbb">216</td>
 <td align=center>250<br><i>(250-280)</i></td>
 <td align=center>215<br><i>(190-280)</i></td>
 <td align=center>280<br><i>(280-300)</i></td>
@@ -407,7 +407,7 @@
 
 <tr>
 <td align=center>GVE</td>
-<td align=center>220</td>
+<td align=center bgcolor="bbbbbb">220</td>
 <td align=center>250<br><i>(250-280)</i></td>
 <td align=center>220<br><i>(190-280)</i></td>
 <td align=center>280<br><i>(280-300)</i></td>
@@ -417,7 +417,7 @@
 
 <tr>
 <td align=center>HAFNR</td>
-<td align=center>199</td>
+<td align=center bgcolor="bbbbbb">199</td>
 <td align=center>250<br><i>(250-280)</i></td>
 <td align=center>200<br><i>(190-280)</i></td>
 <td align=center>280<br><i>(280-300)</i></td>
@@ -427,7 +427,7 @@
 
 <tr>
 <td align=center>HANEY</td>
-<td align=center>219</td>
+<td align=center bgcolor="bbbbbb">219</td>
 <td align=center>250<br><i>(250-280)</i></td>
 <td align=center>220<br><i>(190-280)</i></td>
 <td align=center>280<br><i>(280-300)</i></td>
@@ -437,7 +437,7 @@
 
 <tr>
 <td align=center>LDN</td>
-<td align=center>271</td>
+<td align=center bgcolor="bbbbbb">271</td>
 <td align=center>270<br><i>(250-280)</i></td>
 <td align=center>270<br><i>(190-280)</i></td>
 <td align=center>280<br><i>(280-300)</i></td>
@@ -447,7 +447,7 @@
 
 <tr>
 <td align=center>MOL</td>
-<td align=center>242</td>
+<td align=center bgcolor="bbbbbb">242</td>
 <td align=center>250<br><i>(250-280)</i></td>
 <td align=center>240<br><i>(190-280)</i></td>
 <td align=center>280<br><i>(280-300)</i></td>
@@ -457,7 +457,7 @@
 
 <tr>
 <td align=center>OTTTO</td>
-<td align=center>271</td>
+<td align=center bgcolor="bbbbbb">271</td>
 <td align=center>270<br><i>(250-280)</i></td>
 <td align=center>270<br><i>(190-280)</i></td>
 <td align=center>280<br><i>(280-300)</i></td>
@@ -467,7 +467,7 @@
 
 <tr>
 <td align=center>POOCH</td>
-<td align=center>209</td>
+<td align=center bgcolor="bbbbbb">209</td>
 <td align=center>250<br><i>(250-280)</i></td>
 <td align=center>210<br><i>(190-280)</i></td>
 <td align=center>280<br><i>(280-300)</i></td>
@@ -477,7 +477,7 @@
 
 <tr>
 <td align=center>RAMAY</td>
-<td align=center>282</td>
+<td align=center bgcolor="bbbbbb">282</td>
 <td align=center>280<br><i>(250-280)</i></td>
 <td align=center>280<br><i>(190-280)</i></td>
 <td align=center>280<br><i>(280-300)</i></td>
@@ -487,7 +487,7 @@
 
 <tr>
 <td align=center>RNLDI</td>
-<td align=center>255</td>
+<td align=center bgcolor="bbbbbb">255</td>
 <td align=center>255<br><i>(250-280)</i></td>
 <td align=center>255<br><i>(190-280)</i></td>
 <td align=center>280<br><i>(280-300)</i></td>


### PR DESCRIPTION
In IAD tower-issued departure headings, renamed "ideal heading" to "ref hdg (do not issue)" and grayed-out column, so it's more clear that those are not to be issued but form the basis for the preferred heading in each config.